### PR TITLE
Update to sketch-file-format@3.6.6

### DIFF
--- a/.changeset/cold-plants-matter.md
+++ b/.changeset/cold-plants-matter.md
@@ -1,0 +1,5 @@
+---
+'@sketch-hq/sketch-file-format-ts': patch
+---
+
+Update to sketch-file-format@3.6.6.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "types": "dist/cjs/index",
   "module": "dist/esm/index",
   "license": "MIT",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "repository": "github:sketch-hq/sketch-file-format-ts",
   "keywords": [
     "sketch",
@@ -20,7 +22,7 @@
     "@changesets/cli": "2.6.5",
     "@sketch-hq/sketch-file-format-1": "npm:@sketch-hq/sketch-file-format@1.1.7",
     "@sketch-hq/sketch-file-format-2": "npm:@sketch-hq/sketch-file-format@2.0.3",
-    "@sketch-hq/sketch-file-format-3": "npm:@sketch-hq/sketch-file-format@3.6.2",
+    "@sketch-hq/sketch-file-format-3": "npm:@sketch-hq/sketch-file-format@3.6.6",
     "@types/humps": "1.1.3",
     "@types/jest": "25.2.1",
     "@types/node": "13.7.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -691,10 +691,10 @@
   resolved "https://registry.yarnpkg.com/@sketch-hq/sketch-file-format/-/sketch-file-format-2.0.3.tgz#ed3077b6e146c947b4fe144ef0cacfc67b7e507e"
   integrity sha512-l/sLUhHayJEair70vQEGBAldpR3K8Xb+WqZGlrVtJT3aZVGGnEAT8i8n8qNMECWBdEojTxC3gKqgiJu9U98nDw==
 
-"@sketch-hq/sketch-file-format-3@npm:@sketch-hq/sketch-file-format@3.6.2":
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/@sketch-hq/sketch-file-format/-/sketch-file-format-3.6.2.tgz#44a33f1917172ccc4a0fd0fc88e4071dd87ae9cf"
-  integrity sha512-I6Dw7Wkj6zqsXreJKwN+Hzr8dsGzmTHjSh7cMWqkVBy9SbHw8z+8YTRvDW5qoFiYs5DIREzZYb0mQeuFJoX1xg==
+"@sketch-hq/sketch-file-format-3@npm:@sketch-hq/sketch-file-format@3.6.6":
+  version "3.6.6"
+  resolved "https://registry.yarnpkg.com/@sketch-hq/sketch-file-format/-/sketch-file-format-3.6.6.tgz#cbcc93ef92dc5eb34575940e6dccf55d368c959e"
+  integrity sha512-cM/2jaMoDIHtfOeL9szogi6zqQPzyGBLAt7zTPe6CvJoQlb/EWPX8ZSw0W2MRjuRoErG9auXrgFZs+EQ5vo4Ng==
   dependencies:
     "@types/json-schema" "7.0.4"
 


### PR DESCRIPTION
## Description

Updates to `sketch-file-format@3.6.6` in order to fix incorrect types generated for the boolean operations enum.

## Related issues

- Fixes: #27
- Original fix in the file format https://github.com/sketch-hq/sketch-file-format/pull/107 
- Fix released from https://github.com/sketch-hq/sketch-file-format/pull/111